### PR TITLE
feat(comms): add contact/thread/message models and migrations

### DIFF
--- a/apps/backend/app/core/db.py
+++ b/apps/backend/app/core/db.py
@@ -1,8 +1,8 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker, declarative_base
+from sqlalchemy.orm import sessionmaker
 
 from app.core.config import settings
+from app.models.base import Base
 
 engine = create_engine(settings.POSTGRES_URL, pool_pre_ping=True, future=True)
 SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False, future=True)
-Base = declarative_base()

--- a/apps/backend/app/models/__init__.py
+++ b/apps/backend/app/models/__init__.py
@@ -1,1 +1,7 @@
-# Database models
+"""Database models."""
+
+from app.models.contact import Contact
+from app.models.thread import Thread
+from app.models.message import Message
+
+__all__ = ["Contact", "Thread", "Message"]

--- a/apps/backend/app/models/contact.py
+++ b/apps/backend/app/models/contact.py
@@ -1,0 +1,17 @@
+from typing import Optional
+from sqlalchemy import JSON
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+
+class Contact(Base):
+    __tablename__ = "contact"
+
+    org_id: Mapped[str] = mapped_column(index=True)
+    name: Mapped[str]
+    emails: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    phones: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    telegram_id: Mapped[Optional[str]] = mapped_column(index=True, nullable=True)
+    tags: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+

--- a/apps/backend/app/models/message.py
+++ b/apps/backend/app/models/message.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Index, JSON, Text
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import ForeignKey
+
+from app.models.base import Base
+
+
+class Message(Base):
+    __tablename__ = "message"
+
+    thread_id: Mapped[str] = mapped_column(ForeignKey("thread.id"), index=True)
+    org_id: Mapped[str] = mapped_column(index=True)
+    direction: Mapped[str]
+    channel: Mapped[str]
+    body: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    attachments: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
+    sent_at: Mapped[Optional[datetime]] = mapped_column(index=True, nullable=True)
+    delivered_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    read_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+    provider_message_id: Mapped[Optional[str]] = mapped_column(index=True, nullable=True)
+    status: Mapped[str] = mapped_column(default="pending")
+
+
+Index("ix_message_thread_id_sent_at", Message.thread_id, Message.sent_at)
+

--- a/apps/backend/app/models/thread.py
+++ b/apps/backend/app/models/thread.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Index
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy import ForeignKey
+
+from app.models.base import Base
+
+
+class Thread(Base):
+    __tablename__ = "thread"
+
+    org_id: Mapped[str] = mapped_column(index=True)
+    contact_id: Mapped[Optional[str]] = mapped_column(ForeignKey("contact.id"), index=True, nullable=True)
+    deal_id: Mapped[Optional[str]] = mapped_column(index=True, nullable=True)
+    subject: Mapped[Optional[str]] = mapped_column(nullable=True)
+    channel: Mapped[str] = mapped_column(index=True)
+    status: Mapped[str] = mapped_column(default="open")
+    last_message_at: Mapped[Optional[datetime]] = mapped_column(nullable=True)
+
+
+Index("ix_thread_org_id_deal_id", Thread.org_id, Thread.deal_id)
+

--- a/apps/backend/migrations/versions/2025_08_19_client_comms_models.py
+++ b/apps/backend/migrations/versions/2025_08_19_client_comms_models.py
@@ -1,0 +1,73 @@
+"""client comms models
+
+Revision ID: 20250819_client_comms_models
+Revises: 20250119_init
+Create Date: 2024-08-19 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "20250819_client_comms_models"
+down_revision = "20250119_init"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "contact",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("org_id", sa.String(), index=True, nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("emails", sa.JSON(), nullable=False),
+        sa.Column("phones", sa.JSON(), nullable=False),
+        sa.Column("telegram_id", sa.String(), nullable=True),
+        sa.Column("tags", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+
+    op.create_table(
+        "thread",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("org_id", sa.String(), index=True, nullable=False),
+        sa.Column("contact_id", sa.String(), sa.ForeignKey("contact.id"), index=True, nullable=True),
+        sa.Column("deal_id", sa.String(), index=True, nullable=True),
+        sa.Column("subject", sa.String(), nullable=True),
+        sa.Column("channel", sa.String(), index=True, nullable=False),
+        sa.Column("status", sa.String(), nullable=False, server_default="open"),
+        sa.Column("last_message_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+    op.create_index("ix_thread_org_id_deal_id", "thread", ["org_id", "deal_id"])
+
+    op.create_table(
+        "message",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("thread_id", sa.String(), sa.ForeignKey("thread.id"), nullable=False),
+        sa.Column("org_id", sa.String(), index=True, nullable=False),
+        sa.Column("direction", sa.String(), nullable=False),
+        sa.Column("channel", sa.String(), nullable=False),
+        sa.Column("body", sa.Text(), nullable=True),
+        sa.Column("attachments", sa.JSON(), nullable=True),
+        sa.Column("sent_at", sa.DateTime(), nullable=True),
+        sa.Column("delivered_at", sa.DateTime(), nullable=True),
+        sa.Column("read_at", sa.DateTime(), nullable=True),
+        sa.Column("provider_message_id", sa.String(), nullable=True),
+        sa.Column("status", sa.String(), nullable=False, server_default="pending"),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+    )
+    op.create_index("ix_message_thread_id_sent_at", "message", ["thread_id", "sent_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_message_thread_id_sent_at", table_name="message")
+    op.drop_table("message")
+    op.drop_index("ix_thread_org_id_deal_id", table_name="thread")
+    op.drop_table("thread")
+    op.drop_table("contact")
+


### PR DESCRIPTION
## Summary
- set DB base to use shared model base
- introduce contact, thread, and message models
- migration for new comms tables

## Testing
- `make rev m="client comms models"` *(fails: Name or service not known)*
- `make migrate` *(fails: Name or service not known)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a52fa89a2c832a93f74e5bdac479bf